### PR TITLE
feat(view): add reusable error message component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juztadrop",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": false,
   "scripts": {
     "prepare": "husky",

--- a/view/src/components/common/ErrorMessage.tsx
+++ b/view/src/components/common/ErrorMessage.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { cn } from '@/lib/common';
+
+export type ErrorMessageVariant = 'full' | 'text';
+
+export interface ErrorMessageProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  variant?: ErrorMessageVariant;
+}
+
+export function ErrorMessage({
+  variant = 'text',
+  className,
+  children,
+  role = 'alert',
+  ...props
+}: ErrorMessageProps) {
+  return (
+    <p
+      role={role}
+      className={cn(
+        'text-2xl font-normal text-destructive',
+        variant === 'full' &&
+          'w-full rounded-xl bg-destructive px-6 py-4 text-center text-destructive-foreground',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}

--- a/view/src/components/common/index.ts
+++ b/view/src/components/common/index.ts
@@ -1,2 +1,4 @@
 export { InProgressPage } from './InProgressPage';
 export { Dropdown } from './DropDown';
+export { ErrorMessage } from './ErrorMessage';
+export type { ErrorMessageProps, ErrorMessageVariant } from './ErrorMessage';


### PR DESCRIPTION
## Description

Adds a reusable `ErrorMessage` component for validation and error feedback, matching the two variants in the linked Figma design.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Closes #50

## Changes Made

- Added `full` and `text` error-message variants using the existing destructive color tokens.
- Preserved standard paragraph attributes, custom classes, and accessible `role="alert"` semantics.
- Exported the component and its public types from the common component barrel.
- Bumped the root package version from `0.0.31` to `0.0.32` as required by the repository PR gate.

## Testing

- [x] Tested locally
- [x] TypeScript typecheck passes
- [x] Production build passes
- [x] Repository version-bump check passes

### Test Steps

1. `cd view && bun install --frozen-lockfile`
2. `cd view && bun run typecheck`
3. `cd view && bun run build`
4. `bash scripts/version-bump-check.sh origin/main HEAD`

Both variants were also rendered locally and checked at desktop width and a 390px mobile viewport for wrapping and overflow.

## Checklist

- [x] My code follows the project code style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings or errors
- [ ] I added unit tests (the view package has no unit-test runner configured)
- [x] New and existing validation commands pass locally

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No new environment variables

## Breaking Changes

None.